### PR TITLE
Change get_project to init_project

### DIFF
--- a/notebooks/signac_103_A_Basic_Workflow.ipynb
+++ b/notebooks/signac_103_A_Basic_Workflow.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "import signac\n",
     "\n",
-    "project = signac.get_project('projects/tutorial')\n",
+    "project = signac.init_project('projects/tutorial')\n",
     "\n",
     "for job in project:\n",
     "    compute_volume(job)"


### PR DESCRIPTION
The current code assumes that there exists a project at the given location. To make this notebook self-contained, get_project is changed to init_project