### PR TITLE
Modified the link to the mdp files

### DIFF
--- a/projects/flow.gmx-lysozyme-in-water/init.py
+++ b/projects/flow.gmx-lysozyme-in-water/init.py
@@ -6,7 +6,7 @@ import subprocess
 import signac
 
 PDB_URL = "https://files.rcsb.org/download/"
-MDP_URL = "http://www.bevanlab.biochem.vt.edu/Pages/Personal/justin/gmx-tutorials/lysozyme/Files/"
+MDP_URL = "http://www.mdtutorials.com/gmx/lysozyme/Files/"
 
 
 # Initialize signac project


### PR DESCRIPTION
The link to download mdp files in the variable MDP_URL is now obsolete. The link has been updated in the MDP_URL variable and verified that the required files are downloaded.