### PR TITLE
Run treebeard for notebook CI.

### DIFF
--- a/.github/workflows/treebeard.yml
+++ b/.github/workflows/treebeard.yml
@@ -1,0 +1,14 @@
+# Uses https://github.com/treebeardtech/treebeard
+# Run all notebooks on every push and weekly
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    name: Run treebeard
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: treebeardtech/treebeard@master

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,11 @@
 channels:
 - conda-forge
-- defaults
 dependencies:
-- notebook=4
-- python=3
-- numpy=1.12
+- notebook>=4
+- python>=3
+- numpy>=1.12
 - pandas
 - matplotlib=3
 - hoomd=2
-- signac=0.9
-- signac-flow=0.6
+- signac>=1.5
+- signac-flow>=0.11

--- a/index.ipynb
+++ b/index.ipynb
@@ -55,9 +55,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/index.ipynb
+++ b/index.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "## Advanced Topics\n",
     "\n",
-    "Onnce you have mastered the basic **signac** functionalities, you can dive into slightly more advanced topics, such as data space indexing and the integration of other tools, such as pandas and databases.\n",
+    "Once you have mastered the basic **signac** functionalities, you can dive into slightly more advanced topics, such as data space indexing and the integration of other tools, such as pandas and databases.\n",
     "Since not all topics within this chapter are necessarily of interest to everyone, sections are less consecutive.\n",
     "Feel free to pick a topic of interest!\n",
     "\n",

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -40,6 +40,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -50,9 +55,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac-flow_HOOMD-blue.ipynb
+++ b/notebooks/signac-flow_HOOMD-blue.ipynb
@@ -22,10 +22,7 @@
     "This example requires signac, signac-flow, HOOMD-blue and numpy.\n",
     "You can install these package for example via conda:\n",
     "```\n",
-    "conda install numpy\n",
-    "conda install -c conda-forge  signac\n",
-    "conda install -c glotzer  signac-flow\n",
-    "conda install -c glotzer  hoomd\n",
+    "conda install -c conda-forge hoomd numpy signac signac-flow\n",
     "```"
    ]
   },
@@ -35,17 +32,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import signac\n",
-    "import flow\n",
     "import hoomd\n",
     "import numpy as np\n",
     "\n",
-    "# Initialize the HOOMD-blue execution context\n",
-    "if hoomd.context.exec_conf is None:\n",
-    "    hoomd.context.initialize('')\n",
+    "import flow\n",
+    "import signac\n",
     "\n",
-    "project_root='projects/tutorial-signac-flow-hoomd-blue'\n",
-    "project = signac.init_project('FlowTutorialHOOMD-BlueProject', project_root)"
+    "# Initialize the HOOMD-blue execution context\n",
+    "hoomd.context.initialize(\"\")\n",
+    "\n",
+    "project_root = \"projects/tutorial-signac-flow-hoomd-blue\"\n",
+    "project = signac.init_project(\"FlowTutorialHOOMD-BlueProject\", project_root)"
    ]
   },
   {
@@ -65,23 +62,26 @@
    "source": [
     "from math import ceil\n",
     "\n",
+    "\n",
     "def init(N):\n",
     "    with hoomd.context.SimulationContext():\n",
-    "        n = ceil(pow(N, 1/3))\n",
-    "        assert n**3 == N\n",
+    "        n = ceil(pow(N, 1 / 3))\n",
+    "        assert n ** 3 == N\n",
     "        hoomd.init.create_lattice(unitcell=hoomd.lattice.sc(a=1.0), n=n)\n",
-    "        hoomd.dump.gsd('init.gsd', period=None, group=hoomd.group.all())\n",
+    "        hoomd.dump.gsd(\"init.gsd\", period=None, group=hoomd.group.all())\n",
+    "\n",
     "\n",
     "def sample_lj(N, sigma, seed, kT, tau, p, tauP, steps, r_cut):\n",
     "    from hoomd import md\n",
-    "    hoomd.init.read_gsd('init.gsd', restart='restart.gsd')\n",
+    "\n",
+    "    hoomd.init.read_gsd(\"init.gsd\", restart=\"restart.gsd\")\n",
     "    group = hoomd.group.all()\n",
-    "    hoomd.dump.gsd('restart.gsd', truncate=True, period=100, phase=0, group=group)\n",
+    "    hoomd.dump.gsd(\"restart.gsd\", truncate=True, period=100, phase=0, group=group)\n",
     "    lj = md.pair.lj(r_cut=r_cut, nlist=md.nlist.cell())\n",
-    "    lj.pair_coeff.set('A', 'A', epsilon=1.0, sigma=sigma)\n",
+    "    lj.pair_coeff.set(\"A\", \"A\", epsilon=1.0, sigma=sigma)\n",
     "    md.integrate.mode_standard(dt=0.005)\n",
     "    md.integrate.npt(group=group, kT=kT, tau=tau, P=p, tauP=tauP)\n",
-    "    hoomd.analyze.log('dump.log', ['volume'], 100, phase=0)\n",
+    "    hoomd.analyze.log(\"dump.log\", [\"volume\"], 100, phase=0)\n",
     "    hoomd.run_upto(steps)"
    ]
   },
@@ -104,16 +104,18 @@
    "source": [
     "def estimate(job):\n",
     "    sp = job.statepoint()\n",
-    "    job.document['V'] = sp['N'] * sp['kT'] / sp['p']\n",
+    "    job.document[\"V\"] = sp[\"N\"] * sp[\"kT\"] / sp[\"p\"]\n",
+    "\n",
     "\n",
     "def sample(job):\n",
     "    import hoomd\n",
+    "\n",
     "    with job:\n",
     "        with hoomd.context.SimulationContext():\n",
     "            try:\n",
-    "                sample_lj(steps=5000, ** job.statepoint())\n",
+    "                sample_lj(steps=5000, **job.statepoint())\n",
     "            finally:\n",
-    "                job.document['sample_step'] = hoomd.get_step()"
+    "                job.document[\"sample_step\"] = hoomd.get_step()"
    ]
   },
   {
@@ -141,26 +143,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class MyProject(flow.FlowProject):\n",
-    "    \n",
     "    def classify(self, job):\n",
-    "        yield 'init'\n",
-    "        if 'V' in job.document:\n",
-    "            yield 'estimated'\n",
-    "        if job.document.get('sample_step', 0) >= 5000:\n",
-    "            yield 'sampled'\n",
-    "    \n",
+    "        yield \"init\"\n",
+    "        if \"V\" in job.document:\n",
+    "            yield \"estimated\"\n",
+    "        if job.document.get(\"sample_step\", 0) >= 5000:\n",
+    "            yield \"sampled\"\n",
+    "\n",
     "    def next_operation(self, job):\n",
     "        labels = set(self.classify(job))\n",
-    "        if 'V' not in job.document:\n",
-    "            return 'estimate'\n",
-    "        if 'sampled' not in labels:\n",
-    "            return 'sample'"
+    "        if \"V\" not in job.document:\n",
+    "            return \"estimate\"\n",
+    "        if \"sampled\" not in labels:\n",
+    "            return \"sample\""
    ]
   },
   {
@@ -199,7 +198,7 @@
     "for p in np.linspace(0.5, 5.0, 10):\n",
     "    sp = dict(N=512, sigma=1.0, seed=42, kT=1.0, p=p, tau=1.0, tauP=1.0, r_cut=2.5)\n",
     "    with project.open_job(sp):\n",
-    "        init(N=sp['N'])"
+    "        init(N=sp[\"N\"])"
    ]
   },
   {
@@ -215,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project.print_status(detailed=True, parameters=['p'])"
+    "project.print_status(detailed=True, parameters=[\"p\"]);"
    ]
   },
   {
@@ -239,7 +238,7 @@
     "            next_op = project.next_operation(job)\n",
     "            if next_op is None:\n",
     "                break\n",
-    "            print('execute', job, next_op)\n",
+    "            print(\"execute\", job, next_op)\n",
     "            globals()[next_op](job)\n",
     "            assert next_op != project.next_operation(job)\n",
     "        else:\n",
@@ -259,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project.print_status()"
+    "project.print_status();"
    ]
   },
   {
@@ -276,12 +275,13 @@
    "outputs": [],
    "source": [
     "def get_volume(job):\n",
-    "    log = np.genfromtxt(job.fn('dump.log'), names=True)\n",
+    "    log = np.genfromtxt(job.fn(\"dump.log\"), names=True)\n",
     "    N = len(log)\n",
-    "    return log[int(0.5 * N):]['volume'].mean(axis=0)\n",
+    "    return log[int(0.5 * N) :][\"volume\"].mean(axis=0)\n",
+    "\n",
     "\n",
     "for job in project:\n",
-    "    print(job.statepoint()['p'], get_volume(job), job.document.get('V'))"
+    "    print(job.statepoint()[\"p\"], get_volume(job), job.document.get(\"V\"))"
    ]
   },
   {
@@ -299,26 +299,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Display plots within the notebook\n",
-    "from matplotlib import pyplot as plt\n",
     "%matplotlib inline\n",
+    "# Display plots within the notebook\n",
+    "\n",
+    "from matplotlib import pyplot as plt\n",
     "\n",
     "V = dict()\n",
     "V_idg = dict()\n",
     "\n",
     "for job in project:\n",
-    "    V[job.statepoint()['p']] = get_volume(job)\n",
-    "    V_idg[job.statepoint()['p']] = job.document['V']\n",
-    "    \n",
+    "    V[job.statepoint()[\"p\"]] = get_volume(job)\n",
+    "    V_idg[job.statepoint()[\"p\"]] = job.document[\"V\"]\n",
+    "\n",
     "p = sorted(V.keys())\n",
     "V = [V[p_] for p_ in p]\n",
     "V_idg = [V_idg[p_] for p_ in p]\n",
     "\n",
-    "plt.plot(p, V, label='LJ')\n",
-    "plt.plot(p, V_idg, label='idG')\n",
-    "plt.xlabel(r'pressure [$\\epsilon / \\sigma^3$]')\n",
-    "plt.ylabel(r'volume [$\\sigma^3$]')\n",
-    "plt.legend()"
+    "plt.plot(p, V, label=\"LJ\")\n",
+    "plt.plot(p, V_idg, label=\"idG\")\n",
+    "plt.xlabel(r\"pressure [$\\epsilon / \\sigma^3$]\")\n",
+    "plt.ylabel(r\"volume [$\\sigma^3$]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
    ]
   },
   {
@@ -331,12 +333,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#% rm -r projects/tutorial-signac-flow-hoomd-blue/workspace"
+    "# %rm -r projects/tutorial-signac-flow-hoomd-blue/workspace"
    ]
   }
  ],
@@ -356,9 +356,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac-flow_Ideal_Gas_Example.ipynb
+++ b/notebooks/signac-flow_Ideal_Gas_Example.ipynb
@@ -20,8 +20,7 @@
     "Make sure you installed signac and signac-flow, e.g., with:\n",
     "\n",
     "```\n",
-    "conda install -c conda-forge  signac\n",
-    "conda install -c glotzer  signac-flow\n",
+    "conda install -c conda-forge signac signac-flow\n",
     "```"
    ]
   },
@@ -31,13 +30,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import signac\n",
-    "import flow\n",
     "import numpy as np\n",
     "\n",
+    "import flow\n",
+    "import signac\n",
     "\n",
     "# Enter the signac project directory\n",
-    "project = signac.init_project('FlowTutorialProject', 'projects/tutorial-signac-flow')"
+    "project = signac.init_project(\"FlowTutorialProject\", \"projects/tutorial-signac-flow\")"
    ]
   },
   {
@@ -73,7 +72,7 @@
    "outputs": [],
    "source": [
     "def compute_volume(job):\n",
-    "    job.document['V'] = V_idg(** job.statepoint())"
+    "    job.document[\"V\"] = V_idg(**job.statepoint())"
    ]
   },
   {
@@ -96,16 +95,15 @@
    "outputs": [],
    "source": [
     "class MyProject(flow.FlowProject):\n",
-    "    \n",
     "    def labels(self, job):\n",
-    "        yield 'init'\n",
-    "        if 'V' in job.document:\n",
-    "            yield 'estimated'\n",
-    "    \n",
+    "        yield \"init\"\n",
+    "        if \"V\" in job.document:\n",
+    "            yield \"estimated\"\n",
+    "\n",
     "    def next_operation(self, job):\n",
     "        labels = set(self.labels(job))\n",
-    "        if 'V' not in job.document:\n",
-    "            return 'compute_volume'"
+    "        if \"V\" not in job.document:\n",
+    "            return \"compute_volume\""
    ]
   },
   {
@@ -121,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = MyProject.get_project(root='projects/tutorial-signac-flow')"
+    "project = MyProject.get_project(root=\"projects/tutorial-signac-flow\")"
    ]
   },
   {
@@ -155,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project.print_status(detailed=True, parameters=['p'])"
+    "project.print_status(detailed=True, parameters=[\"p\"]);"
    ]
   },
   {
@@ -179,7 +177,7 @@
     "            next_op = project.next_operation(job)\n",
     "            if next_op is None:\n",
     "                break\n",
-    "            print('execute', job, next_op)\n",
+    "            print(\"execute\", job, next_op)\n",
     "            globals()[next_op](job)\n",
     "            assert next_op != project.next_operation(job)\n",
     "        else:\n",
@@ -199,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project.print_status()"
+    "project.print_status();"
    ]
   },
   {
@@ -216,7 +214,7 @@
    "outputs": [],
    "source": [
     "for job in project:\n",
-    "    print(job.statepoint()['p'], job.document.get('V'))"
+    "    print(job.statepoint()[\"p\"], job.document.get(\"V\"))"
    ]
   },
   {
@@ -232,22 +230,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import pyplot as plt\n",
     "%matplotlib inline\n",
     "\n",
-    "V = dict()\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "V = {}\n",
     "\n",
     "for job in project:\n",
-    "    V[job.statepoint()['p']] = job.document['V']\n",
-    "    \n",
+    "    V[job.statepoint()[\"p\"]] = job.document[\"V\"]\n",
+    "\n",
     "p = sorted(V.keys())\n",
     "V = [V[p_] for p_ in p]\n",
     "print(V)\n",
     "\n",
-    "plt.plot(p, V, label='idG')\n",
-    "plt.xlabel(r'pressure [$\\epsilon / \\sigma^3$]')\n",
-    "plt.ylabel(r'volume [$\\sigma^3$]')\n",
-    "plt.legend()"
+    "plt.plot(p, V, label=\"idG\")\n",
+    "plt.xlabel(r\"pressure [$\\epsilon / \\sigma^3$]\")\n",
+    "plt.ylabel(r\"volume [$\\sigma^3$]\")\n",
+    "plt.legend()\n",
+    "plt.show()"
    ]
   },
   {
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#% rm -r projects/tutorial-signac-flow/workspace"
+    "# %rm -r projects/tutorial-signac-flow/workspace"
    ]
   }
  ],
@@ -303,9 +303,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_101_Getting_Started.ipynb
+++ b/notebooks/signac_101_Getting_Started.ipynb
@@ -22,7 +22,7 @@
     "```pip install signac --user```\n",
     "\n",
     "\n",
-    "Please refer to the [documentation](http://signac.readthedocs.io/en/latest/installation.html#installation) for detailed instructions on how to install signac.\n",
+    "Please refer to the [documentation](https://docs.signac.io/en/latest/installation.html#installation) for detailed instructions on how to install signac.\n",
     "\n",
     "After succesful installation, the following cell should execute without error:"
    ]
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "import signac\n",
-    "assert signac.__version__ >= '0.8.0'"
+    "assert signac.__version__ >= '1.5.0'"
    ]
   },
   {
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% rm -rf projects/tutorial/workspace"
+    "%rm -rf projects/tutorial/workspace"
    ]
   },
   {
@@ -69,9 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def V_idg(N, kT, p):\n",
@@ -239,7 +237,7 @@
    "outputs": [],
    "source": [
     "job2 = project.open_job({'kT': 1.0, 'N': 1000, 'p': 1.0})\n",
-    "print(job.get_id(), job2.get_id())"
+    "print(job.id, job2.id)"
    ]
   },
   {
@@ -398,9 +396,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_101_Getting_Started.ipynb
+++ b/notebooks/signac_101_Getting_Started.ipynb
@@ -34,7 +34,8 @@
    "outputs": [],
    "source": [
     "import signac\n",
-    "assert signac.__version__ >= '1.5.0'"
+    "\n",
+    "assert signac.__version__ >= \"1.5.0\""
    ]
   },
   {
@@ -92,7 +93,7 @@
    "source": [
     "import signac\n",
     "\n",
-    "project = signac.init_project('TutorialProject', 'projects/tutorial')"
+    "project = signac.init_project(\"TutorialProject\", \"projects/tutorial\")"
    ]
   },
   {
@@ -114,9 +115,9 @@
    "outputs": [],
    "source": [
     "for p in 0.1, 1.0, 10.0:\n",
-    "    sp = {'p': p, 'kT': 1.0, 'N': 1000}\n",
+    "    sp = {\"p\": p, \"kT\": 1.0, \"N\": 1000}\n",
     "    job = project.open_job(sp)\n",
-    "    job.document['V'] = V_idg(**sp)"
+    "    job.document[\"V\"] = V_idg(**sp)"
    ]
   },
   {
@@ -133,7 +134,7 @@
    "outputs": [],
    "source": [
     "for job in project:\n",
-    "    print(job.sp.p, job.document['V'])"
+    "    print(job.sp.p, job.document[\"V\"])"
    ]
   },
   {
@@ -183,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job = project.open_job({'p': 1.0, 'kT': 1.0, 'N': 1000})"
+    "job = project.open_job({\"p\": 1.0, \"kT\": 1.0, \"N\": 1000})"
    ]
   },
   {
@@ -218,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(job.statepoint()['p'])\n",
+    "print(job.statepoint()[\"p\"])\n",
     "print(job.sp.p)"
    ]
   },
@@ -236,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job2 = project.open_job({'kT': 1.0, 'N': 1000, 'p': 1.0})\n",
+    "job2 = project.open_job({\"kT\": 1.0, \"N\": 1000, \"p\": 1.0})\n",
     "print(job.id, job2.id)"
    ]
   },
@@ -273,10 +274,10 @@
    "source": [
     "import os\n",
     "\n",
-    "fn_out = os.path.join(job.workspace(), 'V.txt')\n",
-    "with open(fn_out, 'w') as file:\n",
-    "    V = V_idg(** job.statepoint())\n",
-    "    file.write(str(V) + '\\n')"
+    "fn_out = os.path.join(job.workspace(), \"V.txt\")\n",
+    "with open(fn_out, \"w\") as file:\n",
+    "    V = V_idg(**job.statepoint())\n",
+    "    file.write(str(V) + \"\\n\")"
    ]
   },
   {
@@ -292,9 +293,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(job.fn('V.txt'), 'w') as file:\n",
-    "    V = V_idg(** job.statepoint())\n",
-    "    file.write(str(V) + '\\n')"
+    "with open(job.fn(\"V.txt\"), \"w\") as file:\n",
+    "    V = V_idg(**job.statepoint())\n",
+    "    file.write(str(V) + \"\\n\")"
    ]
   },
   {
@@ -313,8 +314,8 @@
    "outputs": [],
    "source": [
     "with job:\n",
-    "    with open('V.txt', 'w') as file:\n",
-    "        file.write(str(V) + '\\n')"
+    "    with open(\"V.txt\", \"w\") as file:\n",
+    "        file.write(str(V) + \"\\n\")"
    ]
   },
   {
@@ -331,7 +332,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "job.document['V'] = V_idg(** job.statepoint())\n",
+    "job.document[\"V\"] = V_idg(**job.statepoint())\n",
     "print(job.statepoint(), job.document)"
    ]
   },
@@ -349,9 +350,9 @@
    "outputs": [],
    "source": [
     "for pressure in 0.1, 1.0, 10.0:\n",
-    "    statepoint = {'p': pressure, 'kT': 1.0, 'N': 1000}\n",
+    "    statepoint = {\"p\": pressure, \"kT\": 1.0, \"N\": 1000}\n",
     "    job = project.open_job(statepoint)\n",
-    "    job.document['V'] = V_idg(** job.statepoint())"
+    "    job.document[\"V\"] = V_idg(**job.statepoint())"
    ]
   },
   {

--- a/notebooks/signac_102_Exploring_Data.ipynb
+++ b/notebooks/signac_102_Exploring_Data.ipynb
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "project.create_linked_view(prefix='projects/tutorial/view')\n",
-    "% ls projects/tutorial/view"
+    "%ls projects/tutorial/view"
    ]
   },
   {
@@ -162,8 +162,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% ls 'projects/tutorial/view/p_1.0/job/'\n",
-    "% cat 'projects/tutorial/view/p_1.0/job/V.txt'"
+    "%ls 'projects/tutorial/view/p/1.0/job/'\n",
+    "%cat 'projects/tutorial/view/p/1.0/job/V.txt'"
    ]
   },
   {
@@ -199,9 +199,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_102_Exploring_Data.ipynb
+++ b/notebooks/signac_102_Exploring_Data.ipynb
@@ -27,7 +27,8 @@
    "outputs": [],
    "source": [
     "import signac\n",
-    "project = signac.get_project('projects/tutorial')"
+    "\n",
+    "project = signac.get_project(\"projects/tutorial\")"
    ]
   },
   {
@@ -43,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for job in project.find_jobs({'p': 10.0}):\n",
+    "for job in project.find_jobs({\"p\": 10.0}):\n",
     "    print(job.statepoint())"
    ]
   },
@@ -121,7 +122,7 @@
    "source": [
     "index = signac.Collection(project.index())\n",
     "\n",
-    "for doc in index.find({'statepoint.p': 10.0}):\n",
+    "for doc in index.find({\"statepoint.p\": 10.0}):\n",
     "    print(doc)"
    ]
   },
@@ -142,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project.create_linked_view(prefix='projects/tutorial/view')\n",
+    "project.create_linked_view(prefix=\"projects/tutorial/view\")\n",
     "%ls projects/tutorial/view"
    ]
   },

--- a/notebooks/signac_103_A_Basic_Workflow.ipynb
+++ b/notebooks/signac_103_A_Basic_Workflow.ipynb
@@ -31,6 +31,7 @@
    "source": [
     "from time import sleep\n",
     "\n",
+    "\n",
     "def V_idg(N, p, kT, cost=0):\n",
     "    sleep(cost)\n",
     "    return N * kT / p"
@@ -64,11 +65,11 @@
    "outputs": [],
    "source": [
     "def compute_volume(job):\n",
-    "    print('Computing volume of', job)\n",
+    "    print(\"Computing volume of\", job)\n",
     "    V = V_idg(cost=1, **job.statepoint())\n",
-    "    job.document['V'] = V\n",
-    "    with open(job.fn('V.txt'), 'w') as file:\n",
-    "        file.write(str(V) + '\\n')"
+    "    job.document[\"V\"] = V\n",
+    "    with open(job.fn(\"V.txt\"), \"w\") as file:\n",
+    "        file.write(str(V) + \"\\n\")"
    ]
   },
   {
@@ -97,7 +98,7 @@
    "source": [
     "import signac\n",
     "\n",
-    "project = signac.init_project('projects/tutorial')\n",
+    "project = signac.init_project(\"projects/tutorial\")\n",
     "\n",
     "for job in project:\n",
     "    compute_volume(job)"
@@ -127,18 +128,21 @@
    },
    "outputs": [],
    "source": [
-    "import signac\n",
     "import numpy as np\n",
     "\n",
-    "project = signac.get_project(root='projects/tutorial')\n",
+    "import signac\n",
+    "\n",
+    "project = signac.get_project(root=\"projects/tutorial\")\n",
+    "\n",
     "\n",
     "def init_statepoints(n):\n",
     "    for p in np.linspace(0.1, 10.0, n):\n",
-    "        sp = {'p': p, 'kT': 1.0, 'N': 1000}\n",
+    "        sp = {\"p\": p, \"kT\": 1.0, \"N\": 1000}\n",
     "        job = project.open_job(sp)\n",
     "        job.init()\n",
-    "        print('initialize', job)\n",
-    "        \n",
+    "        print(\"initialize\", job)\n",
+    "\n",
+    "\n",
     "init_statepoints(5)"
    ]
   },
@@ -167,7 +171,7 @@
    "outputs": [],
    "source": [
     "for job in project:\n",
-    "    if 'V' not in job.document:\n",
+    "    if \"V\" not in job.document:\n",
     "        compute_volume(job)"
    ]
   },
@@ -222,9 +226,9 @@
    "outputs": [],
    "source": [
     "def classify(job):\n",
-    "    yield 'init'\n",
-    "    if 'V' in job.document and job.isfile('V.txt'):\n",
-    "        yield 'volume-computed'"
+    "    yield \"init\"\n",
+    "    if \"V\" in job.document and job.isfile(\"V.txt\"):\n",
+    "        yield \"volume-computed\""
    ]
   },
   {
@@ -249,9 +253,9 @@
    },
    "outputs": [],
    "source": [
-    "print('Status: {}'.format(project))\n",
+    "print(\"Status: {}\".format(project))\n",
     "for job in project:\n",
-    "    labels = ', '.join(classify(job))\n",
+    "    labels = \", \".join(classify(job))\n",
     "    p = round(job.sp.p, 1)\n",
     "    print(job, p, labels)"
    ]
@@ -281,7 +285,7 @@
    "source": [
     "for job in project:\n",
     "    labels = classify(job)\n",
-    "    if 'volume-computed' not in labels:\n",
+    "    if \"volume-computed\" not in labels:\n",
     "        compute_volume(job)"
    ]
   },
@@ -306,7 +310,7 @@
    "outputs": [],
    "source": [
     "list(map(compute_volume, project))\n",
-    "print('Done.')"
+    "print(\"Done.\")"
    ]
   },
   {

--- a/notebooks/signac_103_A_Basic_Workflow.ipynb
+++ b/notebooks/signac_103_A_Basic_Workflow.ipynb
@@ -23,7 +23,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "nbpresent": {
      "id": "b89db729-97f6-4734-a219-45f7279c60f1"
     }
@@ -65,7 +64,7 @@
    "outputs": [],
    "source": [
     "def compute_volume(job):\n",
-    "    print('compute volume', job)\n",
+    "    print('Computing volume of', job)\n",
     "    V = V_idg(cost=1, **job.statepoint())\n",
     "    job.document['V'] = V\n",
     "    with open(job.fn('V.txt'), 'w') as file:\n",
@@ -146,7 +145,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
     "nbpresent": {
      "id": "635ead70-2f3a-4676-ba62-d7d1328d52ad"
     }
@@ -217,7 +215,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "nbpresent": {
      "id": "c4103f15-9991-4aae-8844-cacfee4a62b0"
     }
@@ -322,15 +319,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from multiprocessing import Pool\n",
     "\n",
     "with Pool() as pool:\n",
-    "    pool.map(compute_volume, project)"
+    "    pool.map(compute_volume, list(project))"
    ]
   },
   {
@@ -349,7 +344,7 @@
     "from multiprocessing.pool import ThreadPool\n",
     "\n",
     "with ThreadPool() as pool:\n",
-    "    pool.map(compute_volume, project)"
+    "    pool.map(compute_volume, list(project))"
    ]
   },
   {
@@ -373,7 +368,7 @@
    },
    "outputs": [],
    "source": [
-    "# % rm -r projects/tutorial/workspace"
+    "# %rm -r projects/tutorial/workspace"
    ]
   },
   {
@@ -402,7 +397,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   },
   "nbpresent": {
    "slides": {},
@@ -410,5 +405,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_104_Modifying_the_Data_Space.ipynb
+++ b/notebooks/signac_104_Modifying_the_Data_Space.ipynb
@@ -22,9 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -195,7 +193,7 @@
    "source": [
     "We observe that the liquid phase is almost incompressible, while the gas phase is strongly pressure dependent.\n",
     "\n",
-    "The [final section](signac_105_Command_Line_Interface.ipynb) of the first chapter demonstrates how to interact with a **signac** on the command line."
+    "The [final section](signac_105_Command_Line_Interface.ipynb) of the first chapter demonstrates how to interact with **signac** on the command line."
    ]
   }
  ],
@@ -215,9 +213,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_104_Modifying_the_Data_Space.ipynb
+++ b/notebooks/signac_104_Modifying_the_Data_Space.ipynb
@@ -27,9 +27,10 @@
    "source": [
     "import numpy as np\n",
     "\n",
+    "\n",
     "def V_vdW(p, kT, N, a=0, b=0):\n",
     "    \"\"\"Solve the van der Waals equation for V.\"\"\"\n",
-    "    coeffs = [p, - (kT * N + p * N *b), a * N**2, - a * N**3 * b]\n",
+    "    coeffs = [p, -(kT * N + p * N * b), a * N ** 2, -a * N ** 3 * b]\n",
     "    V = sorted(np.roots(coeffs))\n",
     "    return np.real(V).tolist()"
    ]
@@ -74,12 +75,12 @@
    "source": [
     "import signac\n",
     "\n",
-    "project = signac.get_project('projects/tutorial')\n",
+    "project = signac.get_project(\"projects/tutorial\")\n",
     "\n",
     "for job in project:\n",
-    "    if 'a' not in job.sp:\n",
+    "    if \"a\" not in job.sp:\n",
     "        job.sp.a = 0\n",
-    "    if 'b' not in job.sp:\n",
+    "    if \"b\" not in job.sp:\n",
     "        job.sp.b = 0"
    ]
   },
@@ -101,11 +102,11 @@
    "outputs": [],
    "source": [
     "for job in project:\n",
-    "    if 'V' in job.document:\n",
-    "        job.document['V_liq'] = 0\n",
-    "        job.document['V_gas'] = job.document.pop('V')\n",
-    "        with open(job.fn('V.txt'), 'w') as file:\n",
-    "            file.write('{},{}\\n'.format(0, job.document['V_gas']))"
+    "    if \"V\" in job.document:\n",
+    "        job.document[\"V_liq\"] = 0\n",
+    "        job.document[\"V_gas\"] = job.document.pop(\"V\")\n",
+    "        with open(job.fn(\"V.txt\"), \"w\") as file:\n",
+    "            file.write(\"{},{}\\n\".format(0, job.document[\"V_gas\"]))"
    ]
   },
   {
@@ -140,24 +141,26 @@
    "source": [
     "vdW = {\n",
     "    # Source: https://en.wikipedia.org/wiki/Van_der_Waals_constants_(data_page)\n",
-    "    'ideal gas': {'a': 0, 'b': 0},\n",
-    "    'argon':{'a': 1.355, 'b': 0.03201},\n",
-    "    'water': {'a': 5.536, 'b': 0.03049},\n",
+    "    \"ideal gas\": {\"a\": 0, \"b\": 0},\n",
+    "    \"argon\": {\"a\": 1.355, \"b\": 0.03201},\n",
+    "    \"water\": {\"a\": 5.536, \"b\": 0.03049},\n",
     "}\n",
     "\n",
+    "\n",
     "def calc_volume(job):\n",
-    "    V = V_vdW(** job.statepoint())\n",
-    "    job.document['V_liq'] = min(V)\n",
-    "    job.document['V_gas'] = max(V)\n",
-    "    with open(job.fn('V.txt'), 'w') as file:\n",
-    "        file.write('{},{}\\n'.format(min(V), max(V)))\n",
-    "        \n",
+    "    V = V_vdW(**job.statepoint())\n",
+    "    job.document[\"V_liq\"] = min(V)\n",
+    "    job.document[\"V_gas\"] = max(V)\n",
+    "    with open(job.fn(\"V.txt\"), \"w\") as file:\n",
+    "        file.write(\"{},{}\\n\".format(min(V), max(V)))\n",
+    "\n",
+    "\n",
     "for fluid in vdW:\n",
     "    for p in np.linspace(0.1, 10.0, 10):\n",
-    "        sp = {'N': 1000, 'p': p, 'kT': 1.0}\n",
+    "        sp = {\"N\": 1000, \"p\": p, \"kT\": 1.0}\n",
     "        sp.update(vdW[fluid])\n",
     "        job = project.open_job(sp)\n",
-    "        job.document['fluid'] = fluid\n",
+    "        job.document[\"fluid\"] = fluid\n",
     "        calc_volume(job)"
    ]
   },
@@ -177,13 +180,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ps = set((job.statepoint()['p'] for job in project))\n",
+    "ps = set((job.statepoint()[\"p\"] for job in project))\n",
     "for fluid in sorted(vdW):\n",
     "    print(fluid)\n",
     "    for p in sorted(ps):\n",
-    "        jobs = project.find_jobs({'p': p}, doc_filter={'fluid': fluid})\n",
+    "        jobs = project.find_jobs({\"p\": p}, doc_filter={\"fluid\": fluid})\n",
     "        for job in jobs:\n",
-    "            print(round(p, 2), round(job.document['V_liq'], 4), round(job.document['V_gas'], 2))\n",
+    "            print(\n",
+    "                round(p, 2),\n",
+    "                round(job.document[\"V_liq\"], 4),\n",
+    "                round(job.document[\"V_gas\"], 2),\n",
+    "            )\n",
     "    print()"
    ]
   },

--- a/notebooks/signac_105_Command_Line_Interface.ipynb
+++ b/notebooks/signac_105_Command_Line_Interface.ipynb
@@ -41,8 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% rm -rf projects/tutorial/cli\n",
-    "% mkdir -p projects/tutorial/cli"
+    "%rm -rf projects/tutorial/cli\n",
+    "%mkdir -p projects/tutorial/cli"
    ]
   },
   {
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% cd projects/tutorial/cli"
+    "%cd projects/tutorial/cli"
    ]
   },
   {
@@ -404,9 +404,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_105_Command_Line_Interface.ipynb
+++ b/notebooks/signac_105_Command_Line_Interface.ipynb
@@ -225,14 +225,16 @@
    "source": [
     "import signac\n",
     "\n",
+    "\n",
     "def V_idg(N, p, kT):\n",
     "    return N * kT / p\n",
     "\n",
+    "\n",
     "project = signac.get_project()\n",
     "for p in 0.1, 1.0, 10.0:\n",
-    "    sp = {'p': p, 'kT': 1.0, 'N': 1000}\n",
+    "    sp = {\"p\": p, \"kT\": 1.0, \"N\": 1000}\n",
     "    job = project.open_job(sp)\n",
-    "    job.document['V'] = V_idg(**sp)"
+    "    job.document[\"V\"] = V_idg(**sp)"
    ]
   },
   {

--- a/notebooks/signac_201_Advanced_Indexing.ipynb
+++ b/notebooks/signac_201_Advanced_Indexing.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import signac\n",
     "\n",
-    "project = signac.get_project(root='projects/tutorial')\n",
+    "project = signac.get_project(root=\"projects/tutorial\")\n",
     "index = list(project.index())\n",
     "\n",
     "for doc in index[:3]:\n",
@@ -36,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "index = signac.Collection(project.index())"
@@ -57,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for doc in index.find({'statepoint.p': 0.1}):\n",
+    "for doc in index.find({\"statepoint.p\": 0.1}):\n",
     "    print(doc)"
    ]
   },
@@ -75,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "index = signac.Collection(project.index('.*\\.txt'))\n",
+    "index = signac.Collection(project.index(\".*\\.txt\"))\n",
     "for doc in index.find(limit=2):\n",
     "    print(doc)"
    ]
@@ -96,8 +94,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "index = signac.Collection(project.index({'.*\\.txt': 'TextFile'}))\n",
-    "print(index.find_one({'format': 'TextFile'}))"
+    "index = signac.Collection(project.index({\".*\\.txt\": \"TextFile\"}))\n",
+    "print(index.find_one({\"format\": \"TextFile\"}))"
    ]
   },
   {
@@ -120,12 +118,12 @@
    "outputs": [],
    "source": [
     "# Let's make sure to remoe any remnants from previous runs...\n",
-    "% rm -f projects/tutorial/signac_access.py\n",
+    "%rm -f projects/tutorial/signac_access.py\n",
     "\n",
     "# This will generate a minimal access module:\n",
     "project.create_access_module(master=False)\n",
     "\n",
-    "% cat projects/tutorial/signac_access.py"
+    "%cat projects/tutorial/signac_access.py"
    ]
   },
   {
@@ -166,14 +164,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "access_module = \\\n",
-    "\"\"\"import signac\n",
+    "access_module = \"\"\"import signac\n",
     "\n",
     "def get_indeces(root):\n",
     "    yield signac.get_project(root).index({'.*\\.txt': 'TextFile'})\n",
     "\"\"\"\n",
     "\n",
-    "with open('projects/tutorial/signac_access.py', 'w') as file:\n",
+    "with open(\"projects/tutorial/signac_access.py\", \"w\") as file:\n",
     "    file.write(access_module)"
    ]
   },
@@ -191,7 +188,7 @@
    "outputs": [],
    "source": [
     "master_index = signac.Collection(signac.index())\n",
-    "print(master_index.find_one({'format': 'TextFile'}))"
+    "print(master_index.find_one({\"format\": \"TextFile\"}))"
    ]
   },
   {
@@ -207,10 +204,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for doc in master_index.find({'format': 'TextFile'}, limit=3):\n",
+    "for doc in master_index.find({\"format\": \"TextFile\"}, limit=3):\n",
     "    with signac.fetch(doc) as file:\n",
-    "        p = doc['statepoint']['p']\n",
-    "        V = [float(v) for v in file.read().strip().split(',')]\n",
+    "        p = doc[\"statepoint\"][\"p\"]\n",
+    "        V = [float(v) for v in file.read().strip().split(\",\")]\n",
     "        print(p, V)"
    ]
   },
@@ -247,9 +244,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_202_Integration_with_pandas.ipynb
+++ b/notebooks/signac_202_Integration_with_pandas.ipynb
@@ -18,10 +18,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import signac\n",
     "import pandas as pd\n",
     "\n",
-    "project = signac.get_project(root='projects/tutorial')"
+    "import signac\n",
+    "\n",
+    "project = signac.get_project(root=\"projects/tutorial\")"
    ]
   },
   {
@@ -54,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_index = df_index.set_index(['_id'])\n",
+    "df_index = df_index.set_index([\"_id\"])\n",
     "df_index.head()"
    ]
   },
@@ -71,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "statepoints = {doc['_id']: doc['statepoint'] for doc in project.index()}\n",
+    "statepoints = {doc[\"_id\"]: doc[\"statepoint\"] for doc in project.index()}\n",
     "df = pd.DataFrame(statepoints).T.join(df_index)\n",
     "df.head()"
    ]
@@ -89,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[(df.fluid=='argon') & (df.p > 2.0) & (df.p <= 5.0)].V_gas.mean()"
+    "df[(df.fluid == \"argon\") & (df.p > 2.0) & (df.p <= 5.0)].V_gas.mean()"
    ]
   },
   {
@@ -105,10 +106,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% matplotlib inline\n",
+    "%matplotlib inline\n",
     "\n",
-    "df_water = df[df.fluid=='argon'][['p', 'V_liq', 'V_gas']]\n",
-    "df_water.sort_values('p').set_index('p').plot(logy=True)"
+    "df_water = df[df.fluid == \"argon\"][[\"p\", \"V_liq\", \"V_gas\"]]\n",
+    "df_water.sort_values(\"p\").set_index(\"p\").plot(logy=True)\n",
+    "plt.show()"
    ]
   },
   {
@@ -126,12 +128,13 @@
    "source": [
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "for fluid, group in df[df.p < 2].groupby('fluid'):\n",
-    "    d = group.sort_values('p')\n",
-    "    plt.plot(d['p'], d['V_gas'] / d['N'], label=fluid)\n",
-    "plt.xlabel('p')\n",
-    "plt.ylabel(r'$\\rho_{gas}$')\n",
-    "plt.legend(loc=0)"
+    "for fluid, group in df[df.p < 2].groupby(\"fluid\"):\n",
+    "    d = group.sort_values(\"p\")\n",
+    "    plt.plot(d[\"p\"], d[\"V_gas\"] / d[\"N\"], label=fluid)\n",
+    "plt.xlabel(\"p\")\n",
+    "plt.ylabel(r\"$\\rho_{gas}$\")\n",
+    "plt.legend(loc=0)\n",
+    "plt.show()"
    ]
   }
  ],
@@ -151,9 +154,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_203_Database_Integration.ipynb
+++ b/notebooks/signac_203_Database_Integration.ipynb
@@ -15,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import signac\n",
@@ -27,17 +25,17 @@
     "#\n",
     "\n",
     "# --- 1) USING A LOCAL MONGODB INSTANCE ---\n",
-    "#from pymongo import MongoClient\n",
-    "#client = MongoClient()\n",
-    "#db = client.testing\n",
+    "# from pymongo import MongoClient\n",
+    "# client = MongoClient()\n",
+    "# db = client.testing\n",
     "\n",
     "# --- 2) USING A SIGNAC DATABASE CONFIGURATION ---\n",
-    "db = signac.get_database('testing')\n",
+    "# db = signac.get_database('testing')\n",
     "\n",
-    "index = db.signac_tutorial_index\n",
-    "index.drop()\n",
-    "master_index = db.signac_tutorial_master_index\n",
-    "master_index.drop()"
+    "# index = db.signac_tutorial_index\n",
+    "# index.drop()\n",
+    "# master_index = db.signac_tutorial_master_index\n",
+    "# master_index.drop()"
    ]
   },
   {
@@ -50,14 +48,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "project = signac.get_project(root='projects/tutorial')\n",
+    "# project = signac.get_project(root='projects/tutorial')\n",
     "\n",
-    "signac.export(project.index(), index)"
+    "# signac.export(project.index(), index)"
    ]
   },
   {
@@ -70,12 +66,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "signac.export(signac.index(), master_index, update=True)"
+    "# signac.export(signac.index(), master_index, update=True)"
    ]
   },
   {
@@ -92,15 +86,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
+    "# import numpy as np\n",
     "\n",
-    "query = {\n",
-    "    '$and': [{'statepoint.p': {'$gt': 2.0}}, {'statepoint.p': {'$lte': 5.0}}],\n",
-    "    'fluid': 'water',\n",
-    "    'V_gas': {'$exists': True}}\n",
-    "docs = master_index.find(query)\n",
-    "V = np.array([doc['V_gas'] for doc in docs])\n",
-    "print(V.mean())"
+    "# query = {\n",
+    "#    '$and': [{'statepoint.p': {'$gt': 2.0}}, {'statepoint.p': {'$lte': 5.0}}],\n",
+    "#    'fluid': 'water',\n",
+    "#    'V_gas': {'$exists': True}}\n",
+    "# docs = master_index.find(query)\n",
+    "# V = np.array([doc['V_gas'] for doc in docs])\n",
+    "# print(V.mean())"
    ]
   }
  ],
@@ -120,9 +114,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/notebooks/signac_204_External_Tools.ipynb
+++ b/notebooks/signac_204_External_Tools.ipynb
@@ -35,10 +35,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% pwd\n",
-    "% rm -rf projects/tutorial/cli\n",
-    "% mkdir -p projects/tutorial/cli\n",
-    "% cp idg projects/tutorial/cli"
+    "%pwd\n",
+    "%rm -rf projects/tutorial/cli\n",
+    "%mkdir -p projects/tutorial/cli\n",
+    "%cp idg projects/tutorial/cli"
    ]
   },
   {
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% cd projects/tutorial/cli"
+    "%cd projects/tutorial/cli"
    ]
   },
   {
@@ -215,12 +215,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import signac\n",
     "import json\n",
+    "\n",
+    "import signac\n",
+    "\n",
     "project = signac.get_project()\n",
     "for p in 0.1, 1.0, 10.0:\n",
-    "    job = project.open_job({'N': 1000, 'p': p, 'kT': 1.0})\n",
-    "    cmd = './idg -p {p} --kT {kT} -N {N}'.format(**job.statepoint())\n",
+    "    job = project.open_job({\"N\": 1000, \"p\": p, \"kT\": 1.0})\n",
+    "    cmd = \"./idg -p {p} --kT {kT} -N {N}\".format(**job.statepoint())\n",
     "    cmd += \" > $(signac job -cw '{}')/V.txt\".format(json.dumps(job.statepoint()))\n",
     "    print(cmd)"
    ]
@@ -257,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "% cat `signac project -w`/*/V.txt"
+    "%cat `signac project -w`/*/V.txt"
    ]
   }
  ],
@@ -278,9 +280,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This adds notebook CI using treebeard: https://github.com/treebeardtech/treebeard

There are lots of notebook CI solutions. I picked treebeard because it seems very easy to use.

This might be superseded by #17, since I added `nbval` support there based on a script I've used before. I trust that to be a little more stable over the long run.