### PR TITLE
updating to new binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/csadorf/signac-examples/master?filepath=notebooks%2Findex.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/glotzerlab/signac-examples/master?filepath=notebooks%2F)
 
 # signac - Tutorial and Examples
 


### PR DESCRIPTION
The previous `launch binder` button pointed to simon's prior repo and did not load. I've updated it to point to a working jupyter binder.