### PR TITLE
Use --pretend instead of --test.

### DIFF
--- a/projects/flow.hoomd.lj/test.sh
+++ b/projects/flow.hoomd.lj/test.sh
@@ -1,6 +1,6 @@
 python src/init.py 0
 python src/project.py status -d -p 1
-python src/project.py submit --test
+python src/project.py submit --pretend
 python src/project.py run -o initialize --progress
 python src/project.py run -o estimate --progress
 python src/project.py run -o sample --progress


### PR DESCRIPTION
Fixes syntax update required for signac-flow >= 0.12.0.
