### PR TITLE
Merge tutorial .rst into example notebooks

### DIFF
--- a/notebooks/signac_101_Getting_Started.ipynb
+++ b/notebooks/signac_101_Getting_Started.ipynb
@@ -58,13 +58,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## A minimal example\n",
+    "## Initializing the data space\n",
     "\n",
     "For this tutorial we want to compute the volume of an ideal gas as a function of its pressure and thermal energy using the ideal gas equation\n",
     "\n",
-    "$p V = N kT$, where\n",
+    "$$p V = N kT$$\n",
     "\n",
-    "$N$ refers to the system size, $p$ to the pressure, $kT$ to the thermal energy and $V$ is the volume of the system."
+    "where $N$ refers to the system size, $p$ to the pressure, $kT$ to the thermal energy and $V$ is the volume of the system."
    ]
   },
   {
@@ -81,13 +81,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can execute the complete study in just a few lines of code.\n",
     "First, we initialize the project directory and get a project handle:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,12 +99,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We iterate over the variable of interest *p* and construct a complete state point *sp* which contains all the meta data associated with our data.\n",
-    "In this simple example the meta data is very compact, but in principle the state point may be highly complex.\n",
+    "We iterate over the variable of interest `p` and construct a complete state point `sp`,  a `dict` containing the meta data associated with our data. \n",
     "\n",
-    "Next, we obtain a *job* handle and store the result of the calculation within the *job document*.\n",
-    "The *job document* is a persistent dictionary for storage of simple key-value pairs.\n",
-    "Here, we exploit that the state point dictionary *sp* can easily be passed into the `V_idg()` function using the [keyword expansion syntax](https://docs.python.org/dev/tutorial/controlflow.html#keyword-arguments) (`**sp`)."
+    "\n",
+    "Next, we obtain a `job` handle and store the result of the calculation within the `job document`.\n",
+    "The `job document` is a persistent dictionary for storage of simple key-value pairs.\n",
+    "\n",
+    "Here, we exploit that the state point dictionary `sp` can easily be passed into the `V_idg()` function using the [keyword expansion syntax](https://docs.python.org/dev/tutorial/controlflow.html#keyword-arguments) (`**sp`)."
    ]
   },
   {
@@ -119,6 +119,13 @@
     "    job = project.open_job(sp)\n",
     "    job.document[\"V\"] = V_idg(**sp)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
The tutorial and the first example notebook have a lot of duplicated code, so we've decided to make the first example notebook more of a tutorial, and make sure it contains the necessary content for getting a new user familiar with the basics.

