### PR TITLE
Remove flow.environments commented imports.

### DIFF
--- a/projects/flow.gmx-lysozyme-in-water/project.py
+++ b/projects/flow.gmx-lysozyme-in-water/project.py
@@ -3,9 +3,6 @@ import pexpect  # Used to automate interaction with GROMACS interface.
 import signac
 from flow import FlowProject
 
-# import flow.environments  # uncomment to use default environments
-
-
 gmx_exec = "gmx"  # or use gmx_mpi if available
 mpi_exec = "mpirun"
 

--- a/projects/flow.hello-world/project.py
+++ b/projects/flow.hello-world/project.py
@@ -1,7 +1,5 @@
 from flow import FlowProject
 
-# import flow.environments  # uncomment to use default environments
-
 
 class Project(FlowProject):
     pass

--- a/projects/flow.hoomd.lj/src/project.py
+++ b/projects/flow.hoomd.lj/src/project.py
@@ -7,8 +7,6 @@ status, execute operations and submit them to a cluster. See also:
 """
 from flow import FlowProject
 
-# import flow.environments # uncomment to use default environments
-
 
 class MyProject(FlowProject):
     pass

--- a/projects/flow.minimal/project.py
+++ b/projects/flow.minimal/project.py
@@ -1,7 +1,5 @@
 from flow import FlowProject
 
-# import flow.environments  # uncomment to use default environments
-
 
 class Project(FlowProject):
     pass


### PR DESCRIPTION
This removes the commented-out statements `import flow.environments`. This import is done automatically in recent versions of signac-flow.
