### PR TITLE
Require HOOMD 2 in flow.hoomd.lj.

### DIFF
--- a/projects/flow.hoomd.lj/requirements.txt
+++ b/projects/flow.hoomd.lj/requirements.txt
@@ -1,4 +1,4 @@
-hoomd>=2.1.5
+hoomd>=2.1.5,<3
 jupyter
 matplotlib
 numpy


### PR DESCRIPTION
Tests are failing due to the `flow.hoomd.lj` project requiring HOOMD 2. This PR makes CI pass. See also issue #18: examples should be updated to HOOMD 3.

I will merge this once CI passes.